### PR TITLE
rename kube-storage to csi-addons

### DIFF
--- a/.github/workflows/docker-push.yaml
+++ b/.github/workflows/docker-push.yaml
@@ -30,11 +30,11 @@ jobs:
 
     - name: copy volume-replication-operator repo in go src
       run: |
-        mkdir -p /home/runner/go/src/github.com/kube-storage
-        cp -r /home/runner/work/volume-replication-operator/volume-replication-operator /home/runner/go/src/github.com/kube-storage
+        mkdir -p /home/runner/go/src/github.com/csi-addons
+        cp -r /home/runner/work/volume-replication-operator/volume-replication-operator /home/runner/go/src/github.com/csi-addons
 
     - name: run docker-push
-      working-directory: "/home/runner/go/src/github.com/kube-storage/volume-replication-operator"
+      working-directory: "/home/runner/go/src/github.com/csi-addons/volume-replication-operator"
       env:
         GOPATH: /home/runner/go
       run: |

--- a/.github/workflows/test-and-build.yaml
+++ b/.github/workflows/test-and-build.yaml
@@ -23,11 +23,11 @@ jobs:
 
     - name: copy volume-replication-operator repo in go src
       run: |
-        mkdir -p /home/runner/go/src/github.com/kube-storage
-        cp -r /home/runner/work/volume-replication-operator/volume-replication-operator /home/runner/go/src/github.com/kube-storage
+        mkdir -p /home/runner/go/src/github.com/csi-addons
+        cp -r /home/runner/work/volume-replication-operator/volume-replication-operator /home/runner/go/src/github.com/csi-addons
 
     - name: run tests and build docker image
-      working-directory: "/home/runner/go/src/github.com/kube-storage/volume-replication-operator"
+      working-directory: "/home/runner/go/src/github.com/csi-addons/volume-replication-operator"
       env:
         GOPATH: /home/runner/go
       run: |

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 BUNDLE_IMG ?= controller-bundle:$(VERSION)
 
 # Image URL to use all building/pushing image targets
-IMG ?= quay.io/kubestorage/volumereplication-operator:latest
+IMG ?= quay.io/csiaddons/volumereplication-operator:latest
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:trivialVersions=true,preserveUnknownFields=false"
 

--- a/PROJECT
+++ b/PROJECT
@@ -1,7 +1,7 @@
 domain: storage.openshift.io
 layout: go.kubebuilder.io/v3
 projectName: volume-replication-operator
-repo: github.com/kube-storage/volume-replication-operator
+repo: github.com/csi-addons/volume-replication-operator
 resources:
 - crdVersion: v1
   group: replication

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Overview
 
 Volume Replication Operator is a kubernetes operator that provides common and reusable APIs for storage disaster recovery.
-It is based on [kube-storage/spec](https://github.com/kube-storage/spec) specification and can be used by any storage
+It is based on [csi-addons/spec](https://github.com/csi-addons/spec) specification and can be used by any storage
 provider.
 
 ## Design
@@ -11,7 +11,7 @@ provider.
 Volume Replication Operator follows controller pattern and provides extended APIs for storage disaster recovery.
 The extended APIs are provided via Custom Resource Definition (CRD).
 
-### [VolumeReplicationClass](https://github.com/kube-storage/volume-replication-operator/blob/main/config/crd/bases/replication.storage.openshift.io_volumereplicationclasses.yaml)
+### [VolumeReplicationClass](https://github.com/csi-addons/volume-replication-operator/blob/main/config/crd/bases/replication.storage.openshift.io_volumereplicationclasses.yaml)
 
 `VolumeReplicationClass` is a cluster scoped resource that contains driver related configuration parameters.
 
@@ -37,7 +37,7 @@ spec:
     replication.storage.openshift.io/replication-secret-namespace: secret-namespace
 ```
 
-### [VolumeReplication](https://github.com/kube-storage/volume-replication-operator/blob/main/config/crd/bases/replication.storage.openshift.io_volumereplications.yaml)
+### [VolumeReplication](https://github.com/csi-addons/volume-replication-operator/blob/main/config/crd/bases/replication.storage.openshift.io_volumereplications.yaml)
 
 VolumeReplication is a namespaced resource that contains references to storage object to be replicated and
 VolumeReplicationClass corresponding to the driver providing replication.

--- a/controllers/pvc_test.go
+++ b/controllers/pvc_test.go
@@ -19,8 +19,8 @@ package controllers
 import (
 	"testing"
 
-	replicationv1alpha1 "github.com/kube-storage/volume-replication-operator/api/v1alpha1"
-	"github.com/kube-storage/volume-replication-operator/pkg/config"
+	replicationv1alpha1 "github.com/csi-addons/volume-replication-operator/api/v1alpha1"
+	"github.com/csi-addons/volume-replication-operator/pkg/config"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -30,7 +30,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	replicationv1alpha1 "github.com/kube-storage/volume-replication-operator/api/v1alpha1"
+	replicationv1alpha1 "github.com/csi-addons/volume-replication-operator/api/v1alpha1"
 	// +kubebuilder:scaffold:imports
 )
 

--- a/controllers/tasks/replication/parameters.go
+++ b/controllers/tasks/replication/parameters.go
@@ -17,7 +17,7 @@ limitations under the License.
 package replication
 
 import (
-	"github.com/kube-storage/volume-replication-operator/pkg/client"
+	"github.com/csi-addons/volume-replication-operator/pkg/client"
 )
 
 // CommonRequestParameters holds the common parameters across replication operations.

--- a/controllers/volumereplication_controller.go
+++ b/controllers/volumereplication_controller.go
@@ -33,12 +33,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	replicationlib "github.com/kube-storage/spec/lib/go/replication"
-	replicationv1alpha1 "github.com/kube-storage/volume-replication-operator/api/v1alpha1"
-	"github.com/kube-storage/volume-replication-operator/controllers/tasks"
-	"github.com/kube-storage/volume-replication-operator/controllers/tasks/replication"
-	grpcClient "github.com/kube-storage/volume-replication-operator/pkg/client"
-	"github.com/kube-storage/volume-replication-operator/pkg/config"
+	replicationlib "github.com/csi-addons/spec/lib/go/replication"
+	replicationv1alpha1 "github.com/csi-addons/volume-replication-operator/api/v1alpha1"
+	"github.com/csi-addons/volume-replication-operator/controllers/tasks"
+	"github.com/csi-addons/volume-replication-operator/controllers/tasks/replication"
+	grpcClient "github.com/csi-addons/volume-replication-operator/pkg/client"
+	"github.com/csi-addons/volume-replication-operator/pkg/config"
 )
 
 const (

--- a/controllers/volumereplicationclass.go
+++ b/controllers/volumereplicationclass.go
@@ -19,7 +19,7 @@ package controllers
 import (
 	"context"
 
-	replicationv1alpha1 "github.com/kube-storage/volume-replication-operator/api/v1alpha1"
+	replicationv1alpha1 "github.com/csi-addons/volume-replication-operator/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 )

--- a/controllers/volumereplicationclass_test.go
+++ b/controllers/volumereplicationclass_test.go
@@ -19,7 +19,7 @@ package controllers
 import (
 	"testing"
 
-	replicationv1alpha1 "github.com/kube-storage/volume-replication-operator/api/v1alpha1"
+	replicationv1alpha1 "github.com/csi-addons/volume-replication-operator/api/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,10 @@
-module github.com/kube-storage/volume-replication-operator
+module github.com/csi-addons/volume-replication-operator
 
 go 1.15
 
 require (
+	github.com/csi-addons/spec v0.0.0-20210302071931-ad3b1446aba1
 	github.com/go-logr/logr v0.3.0
-	github.com/kube-storage/spec v0.0.0-20210302071931-ad3b1446aba1
 	github.com/kubernetes-csi/csi-lib-utils v0.9.1
 	github.com/onsi/ginkgo v1.14.1
 	github.com/onsi/gomega v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -80,6 +80,8 @@ github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfc
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
+github.com/csi-addons/spec v0.0.0-20210302071931-ad3b1446aba1 h1:iecYPYpGJEiTaxdl5sNeiJPMx8O+5fnRIE7B5bWxYuQ=
+github.com/csi-addons/spec v0.0.0-20210302071931-ad3b1446aba1/go.mod h1:Mwq4iLiUV4s+K1bszcWU6aMsR5KPsbIYzzszJ6+56vI=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -169,7 +171,6 @@ github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7a
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/gogo/protobuf v1.3.1 h1:DqDEcV5aeaTmdFBePNpYsp3FlcVH/2ISVVM9Qf8PSls=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
-github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -255,8 +256,6 @@ github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/kube-storage/spec v0.0.0-20210302071931-ad3b1446aba1 h1:DTcCQpcvrLEBUmByx/4UmG0Medlv/t4T6WY7GHdeTQc=
-github.com/kube-storage/spec v0.0.0-20210302071931-ad3b1446aba1/go.mod h1:aEM5cuaELIjQPTe4LdyAoR2XvkC5vtd1qz8LgGLf4BQ=
 github.com/kubernetes-csi/csi-lib-utils v0.9.1 h1:sGq6ifVujfMSkfTsMZip44Ttv8SDXvsBlFk9GdYl/b8=
 github.com/kubernetes-csi/csi-lib-utils v0.9.1/go.mod h1:8E2jVUX9j3QgspwHXa6LwyN7IHQDjW9jX3kwoWnSC+M=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
@@ -574,9 +573,7 @@ google.golang.org/grpc v1.21.1/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ij
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=
 google.golang.org/grpc v1.26.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
-google.golang.org/grpc v1.27.0 h1:rRYRFMVgRv6E0D70Skyfsr28tDXIuuPZyWGMPdMcnXg=
 google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
-google.golang.org/grpc v1.29.0 h1:2pJjwYOdkZ9HlN4sWRYBg9ttH5bCOlsueaM+b/oYjwo=
 google.golang.org/grpc v1.29.0/go.mod h1:itym6AZVZYACWQqET3MqgPpjcuV5QH3BxFS3IjizoKk=
 google.golang.org/grpc v1.32.0 h1:zWTV+LMdc3kaiJMSTOFz2UgSBgx8RNQoTGiZu3fR9S0=
 google.golang.org/grpc v1.32.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=

--- a/main.go
+++ b/main.go
@@ -33,9 +33,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	replicationv1alpha1 "github.com/kube-storage/volume-replication-operator/api/v1alpha1"
-	"github.com/kube-storage/volume-replication-operator/controllers"
-	"github.com/kube-storage/volume-replication-operator/pkg/config"
+	replicationv1alpha1 "github.com/csi-addons/volume-replication-operator/api/v1alpha1"
+	"github.com/csi-addons/volume-replication-operator/controllers"
+	"github.com/csi-addons/volume-replication-operator/pkg/config"
 	// +kubebuilder:scaffold:imports
 )
 

--- a/pkg/client/fake/replication-client.go
+++ b/pkg/client/fake/replication-client.go
@@ -17,7 +17,7 @@ limitations under the License.
 package fake
 
 import (
-	replicationlib "github.com/kube-storage/spec/lib/go/replication"
+	replicationlib "github.com/csi-addons/spec/lib/go/replication"
 )
 
 // ReplicationClient to fake replication operations.

--- a/pkg/client/replication-client.go
+++ b/pkg/client/replication-client.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"time"
 
-	replicationlib "github.com/kube-storage/spec/lib/go/replication"
+	replicationlib "github.com/csi-addons/spec/lib/go/replication"
 	"google.golang.org/grpc"
 )
 

--- a/pkg/client/replication-client_test.go
+++ b/pkg/client/replication-client_test.go
@@ -21,11 +21,11 @@ import (
 	"testing"
 	"time"
 
-	replicationlib "github.com/kube-storage/spec/lib/go/replication"
+	replicationlib "github.com/csi-addons/spec/lib/go/replication"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
 
-	"github.com/kube-storage/volume-replication-operator/pkg/client/fake"
+	"github.com/csi-addons/volume-replication-operator/pkg/client/fake"
 )
 
 func TestEnableVolumeReplication(t *testing.T) {


### PR DESCRIPTION
as the org name is changed from kube-storage to csi-addons. rename is done for the same.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>