### PR TITLE
fix status.state when volume is demoted but not ready

### DIFF
--- a/controllers/volumereplication_controller.go
+++ b/controllers/volumereplication_controller.go
@@ -205,7 +205,7 @@ func (r *VolumeReplicationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		replicationErr = r.markVolumeAsSecondary(instance, volumeHandle, parameters, secret)
 		// resync volume if successfully marked Secondary
 		if replicationErr == nil {
-			err := r.updateReplicationStatus(instance, getCurrentReplicationState(instance), "volume is marked secondary")
+			err := r.updateReplicationStatus(instance, getReplicationState(instance), "volume is marked secondary")
 			if err != nil {
 				return ctrl.Result{}, err
 			}


### PR DESCRIPTION
When volume is demoted but  is not ready,  the Status.State is still showing image as primary until the volume is ready. This creates confusion.  This PR changes the Status.State to secondary when volume is demoted but volume is not ready.

Signed-off-by: Santosh Pillai <sapillai@redhat.com>