### PR TITLE
Add github action to push docker image for released tags

### DIFF
--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -1,0 +1,48 @@
+name: Publish Docker image
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  push:
+    name: Push Image
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        go: ["1.15"]
+    steps:
+    - uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go }}
+
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Login to Quay
+      uses: docker/login-action@v1
+      with:
+        registry: quay.io
+        username: ${{ secrets.QUAY_USERNAME }}
+        password: ${{ secrets.QUAY_PASSWORD }}
+
+    - name: copy volume-replication-operator repo in go src
+      run: |
+        mkdir -p /home/runner/go/src/github.com/csi-addons
+        cp -r /home/runner/work/volume-replication-operator/volume-replication-operator /home/runner/go/src/github.com/csi-addons
+
+    - name: run docker-push
+      working-directory: "/home/runner/go/src/github.com/csi-addons/volume-replication-operator"
+      env:
+        GOPATH: /home/runner/go
+      run: |
+        export PATH=$PATH:$GOPATH/bin
+        export VERSION="2.3.2"
+        wget https://github.com/kubernetes-sigs/kubebuilder/releases/download/v"$VERSION"/kubebuilder_"$VERSION"_linux_amd64.tar.gz
+        tar -zxvf kubebuilder_"$VERSION"_linux_amd64.tar.gz
+        export KUBEBUILDER_ASSETS="$(pwd)/kubebuilder_"$VERSION"_linux_amd64/bin"
+        # build and push image with released tag
+        IMG_TAG=${{ github.ref }} make docker-build
+        IMG_TAG=${{ github.ref }} make docker-push

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,9 @@ BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 BUNDLE_IMG ?= controller-bundle:$(VERSION)
 
 # Image URL to use all building/pushing image targets
-IMG ?= quay.io/csiaddons/volumereplication-operator:latest
+IMG_NAME ?= quay.io/csiaddons/volumereplication-operator
+IMG_TAG ?= latest
+IMG=${IMG_NAME}:${IMG_TAG}
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:trivialVersions=true,preserveUnknownFields=false"
 


### PR DESCRIPTION
updated Makefile to accept the IMG_NAME and IMG_TAG as parameters when building and pushing the docker image and also added a GitHub action to push the image based on the release tag to the quay.io

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>