### PR TITLE
requeue the request if the volume is marked as secondary

### DIFF
--- a/controllers/status.go
+++ b/controllers/status.go
@@ -86,6 +86,16 @@ func setFailedPromotionCondition(conditions *[]metav1.Condition, observedGenerat
 	})
 }
 
+// sets conditions when volume is demoted and requeued for resync
+func setOnlyDegradedCondition(conditions *[]metav1.Condition, observedGeneration int64) {
+	setStatusCondition(conditions, metav1.Condition{
+		Type:               ConditionDegraded,
+		Reason:             VolumeDegraded,
+		ObservedGeneration: observedGeneration,
+		Status:             metav1.ConditionTrue,
+	})
+}
+
 // sets conditions when volume was demoted successfully
 func setDemotedCondition(conditions *[]metav1.Condition, observedGeneration int64) {
 	setStatusCondition(conditions, metav1.Condition{


### PR DESCRIPTION
when there is a request to mark the volume as secondary, First demote the image and then requeue the request with a delay of `15 seconds`. This delay is introduced because some storage system needs some time to identify the volume needs resync
or not, when the Reconcile happens again it will demote the volume and then sends a request to check the volume needs resync or not.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>