### PR TITLE
ci: add mergify rule to backport PR

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -54,3 +54,11 @@ pull_request_rules:
       merge: {}
       dismiss_reviews: {}
       delete_head_branch: {}
+  - name: backport patches to release v0.1 branch
+    conditions:
+      - base=main
+      - label=backport-to-release-v0.1
+    actions:
+      backport:
+        branches:
+          - release-v0.1


### PR DESCRIPTION
added mergify rule to backport PR based on the label to a release branch.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>