### PR TITLE
ci: fix release tag fetching in docker publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -20,7 +20,11 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
-
+    
+    - name: Set env
+      # github tag will be like refs/tags/v0.1.0 :10 removes the first 10 characters
+      run: echo RELEASE_VERSION=$(echo ${GITHUB_REF:10}) >> $GITHUB_ENV
+    
     - name: Login to Quay
       uses: docker/login-action@v1
       with:
@@ -44,5 +48,5 @@ jobs:
         tar -zxvf kubebuilder_"$VERSION"_linux_amd64.tar.gz
         export KUBEBUILDER_ASSETS="$(pwd)/kubebuilder_"$VERSION"_linux_amd64/bin"
         # build and push image with released tag
-        IMG_TAG=${{ github.ref }} make docker-build
-        IMG_TAG=${{ github.ref }} make docker-push
+        IMG_TAG="${{ env.RELEASE_VERSION }}" make docker-build
+        IMG_TAG="${{ env.RELEASE_VERSION }}" make docker-push


### PR DESCRIPTION
added code to strip the extra args in release tag reference in GitHub action.

closes #71

sample output at https://github.com/Madhu-1/operator/runs/2672688559?check_suite_focus=true

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>