### PR TITLE
replication: skip disablingReplication if PVC not found

### DIFF
--- a/controllers/volumereplication_controller.go
+++ b/controllers/volumereplication_controller.go
@@ -88,7 +88,7 @@ func (r *VolumeReplicationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	}
 
 	// Get VolumeReplicationClass
-	vrcObj, err := r.getVolumeReplicaCLass(logger, instance.Spec.VolumeReplicationClass)
+	vrcObj, err := r.getVolumeReplicaClass(logger, instance.Spec.VolumeReplicationClass)
 	if err != nil {
 		setFailureCondition(instance)
 		_ = r.updateReplicationStatus(instance, logger, getCurrentReplicationState(instance), err.Error())

--- a/controllers/volumereplicationclass.go
+++ b/controllers/volumereplicationclass.go
@@ -25,7 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-func (r VolumeReplicationReconciler) getVolumeReplicaCLass(logger logr.Logger, vrcName string) (*replicationv1alpha1.VolumeReplicationClass, error) {
+func (r VolumeReplicationReconciler) getVolumeReplicaClass(logger logr.Logger, vrcName string) (*replicationv1alpha1.VolumeReplicationClass, error) {
 	vrcObj := &replicationv1alpha1.VolumeReplicationClass{}
 	err := r.Client.Get(context.TODO(), types.NamespacedName{Name: vrcName}, vrcObj)
 	if err != nil {

--- a/controllers/volumereplicationclass_test.go
+++ b/controllers/volumereplicationclass_test.go
@@ -35,7 +35,7 @@ var mockVolumeReplicationClassObj = &replicationv1alpha1.VolumeReplicationClass{
 	},
 }
 
-func TestGetVolumeReplicaCLass(t *testing.T) {
+func TestGetVolumeReplicaClass(t *testing.T) {
 	testcases := []struct {
 		createVrc       bool
 		errorExpected   bool
@@ -60,7 +60,7 @@ func TestGetVolumeReplicaCLass(t *testing.T) {
 		}
 
 		reconciler := createFakeVolumeReplicationReconciler(t, objects...)
-		vrcObj, err := reconciler.getVolumeReplicaCLass(reconciler.Log, mockVolumeReplicationClassObj.Name)
+		vrcObj, err := reconciler.getVolumeReplicaClass(reconciler.Log, mockVolumeReplicationClassObj.Name)
 
 		if tc.errorExpected {
 			assert.Error(t, err)


### PR DESCRIPTION
If the PVC/objects are deleted in parallel we can easily assume that the replication is removed as the backend storage is deleted and we can remove the finalizer to garbage collect the VR object.
    
fixes: #92
fixes: #38
    
Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>
