### PR TITLE
replication: disable replication if its primary state

### DIFF
--- a/controllers/volumereplication_controller.go
+++ b/controllers/volumereplication_controller.go
@@ -156,12 +156,14 @@ func (r *VolumeReplicationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		}
 	} else {
 		if contains(instance.GetFinalizers(), volumeReplicationFinalizer) {
-			err := r.disableVolumeReplication(logger, volumeHandle, parameters, secret)
-			if err != nil {
-				logger.Error(err, "failed to disable replication")
-				return ctrl.Result{}, err
+			// Disable replication only if it is in primary state
+			if instance.Spec.ReplicationState == replicationv1alpha1.Primary {
+				err := r.disableVolumeReplication(logger, volumeHandle, parameters, secret)
+				if err != nil {
+					logger.Error(err, "failed to disable replication")
+					return ctrl.Result{}, err
+				}
 			}
-
 			logger.Info("removing finalizer from volumeReplication object", "Finalizer", volumeReplicationFinalizer)
 			// once all finalizers have been removed, the object will be deleted
 			instance.ObjectMeta.Finalizers = remove(instance.ObjectMeta.Finalizers, volumeReplicationFinalizer)


### PR DESCRIPTION
if a CR is Secondary, then the assumption is it is Primary somewhere else, or at least there is no conclusive action to actually disable mirroring.

Allowing the Deletion of CR if the image is in a secondary state. and the Replication will be disabled when the VR is deleted on the PVC is in a primary state.

fixes: #91

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>