### PR TITLE
ci: push images only on volume-replication-operator repo

### DIFF
--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -8,6 +8,7 @@ jobs:
   push:
     name: Push Image
     runs-on: ubuntu-latest
+    if: github.repository == 'csi-addons/volume-replication-operator'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/docker-push.yaml
+++ b/.github/workflows/docker-push.yaml
@@ -8,6 +8,7 @@ jobs:
   push:
     name: Push Image
     runs-on: ubuntu-latest
+    if: github.repository == 'csi-addons/volume-replication-operator'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
this commit avoids running push and publish jobs from the forked repo.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>