### PR TITLE
Disable stack trace for error and above error level logs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/onsi/ginkgo v1.14.1
 	github.com/onsi/gomega v1.10.2
 	github.com/stretchr/testify v1.5.1
+	go.uber.org/zap v1.15.0
 	google.golang.org/grpc v1.32.0
 	k8s.io/api v0.19.2
 	k8s.io/apimachinery v0.19.2

--- a/main.go
+++ b/main.go
@@ -45,8 +45,9 @@ const (
 )
 
 var (
-	scheme   = runtime.NewScheme()
-	setupLog = ctrl.Log.WithName("setup")
+	scheme          = runtime.NewScheme()
+	setupLog        = ctrl.Log.WithName("setup")
+	developmentMode bool
 )
 
 func init() {
@@ -61,6 +62,10 @@ func main() {
 	var leaderElectionNamespace string
 	var enableLeaderElection bool
 	var probeAddr string
+
+	if strings.EqualFold(os.Getenv("DEVELOPMENT_MODE"), "true") {
+		developmentMode = true
+	}
 
 	cfg := config.NewDriverConfig()
 


### PR DESCRIPTION
One can still get stack trace for Warn and Error levels by running the operator in development mode by setting the env VOL_REP_DEVELOPER true.