### PR TITLE
ci: update mergify rules to golang 1.16

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -33,7 +33,7 @@ pull_request_rules:
       - "#approved-reviews-by>=2"
       - "#changes-requested-reviews-by=0"
       - "status-success=codespell"
-      - "status-success=test and build (1.15)"
+      - "status-success=test and build (1.16)"
       - "status-success=lint"
       - "status-success=DCO"
     actions:
@@ -47,7 +47,7 @@ pull_request_rules:
       - base~=^(main)|(release-.+)$
       - "#approved-reviews-by>=1"
       - "status-success=codespell"
-      - "status-success=test and build (1.15)"
+      - "status-success=test and build (1.16)"
       - "status-success=lint"
       - "status-success=DCO"
     actions:


### PR DESCRIPTION
as part of #107 we have updated the GitHub action to test with golang 1.16 but mergify rules are not updated for the same. This commit updates the mergify rules for golang 1.16

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>