### PR TITLE
replication: update conditions when resync is done

### DIFF
--- a/controllers/status.go
+++ b/controllers/status.go
@@ -32,6 +32,7 @@ const (
 	Success         = "Success"
 	Promoted        = "Promoted"
 	Demoted         = "Demoted"
+	Resync          = "Resync"
 	FailedToPromote = "FailedToPromote"
 	FailedToDemote  = "FailedToDemote"
 	Error           = "Error"
@@ -177,6 +178,28 @@ func setDegradedCondition(conditions *[]metav1.Condition, observedGeneration int
 		Reason:             ResyncTriggered,
 		ObservedGeneration: observedGeneration,
 		Status:             metav1.ConditionTrue,
+	})
+}
+
+// sets conditions when volume resync is completed and volume is ready to use
+func setVolumeReadyCondition(conditions *[]metav1.Condition, conditionReason string, observedGeneration int64) {
+	setStatusCondition(conditions, metav1.Condition{
+		Type:               ConditionCompleted,
+		Reason:             conditionReason,
+		ObservedGeneration: observedGeneration,
+		Status:             metav1.ConditionTrue,
+	})
+	setStatusCondition(conditions, metav1.Condition{
+		Type:               ConditionDegraded,
+		Reason:             Healthy,
+		ObservedGeneration: observedGeneration,
+		Status:             metav1.ConditionFalse,
+	})
+	setStatusCondition(conditions, metav1.Condition{
+		Type:               ConditionResyncing,
+		Reason:             NotResyncing,
+		ObservedGeneration: observedGeneration,
+		Status:             metav1.ConditionFalse,
 	})
 }
 

--- a/controllers/volumereplication_controller.go
+++ b/controllers/volumereplication_controller.go
@@ -267,6 +267,12 @@ func (r *VolumeReplicationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		setDegradedCondition(&instance.Status.Conditions, instance.Generation)
 		_ = r.updateReplicationStatus(instance, logger, getCurrentReplicationState(instance), "volume is degraded")
 		return ctrl.Result{Requeue: true}, nil
+	} else {
+		if instance.Spec.ReplicationState == replicationv1alpha1.Resync {
+			setVolumeReadyCondition(&instance.Status.Conditions, Resync, instance.Generation)
+		} else if instance.Spec.ReplicationState == replicationv1alpha1.Secondary {
+			setVolumeReadyCondition(&instance.Status.Conditions, Demoted, instance.Generation)
+		}
 	}
 
 	var msg string


### PR DESCRIPTION
updating the conditions as below once the resync
is completed and volume can be marked ready to use

```
status:
    conditions:
    - lastTransitionTime: "2021-09-07T10:23:13Z"
      message: ""
      observedGeneration: 4
      reason: Demoted
      status: "True"
      type: Completed
    - lastTransitionTime: "2021-09-07T10:27:19Z"
      message: ""
      observedGeneration: 4
      reason: Healthy
      status: "False"
      type: Degraded
    - lastTransitionTime: "2021-09-07T10:27:19Z"
      message: ""
      observedGeneration: 4
      reason: NotResyncing
      status: "False"
      type: Resyncing
    lastCompletionTime: "2021-09-07T10:27:19Z"
    lastStartTime: "2021-09-07T09:38:43Z"
    message: volume is marked secondary
    observedGeneration: 4
    state: Secondary
```

The VR status condition will be

* Type completed status be True
* Type Degraded status will be False
* Type Resyncing status will be False

Fixes #101 
Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>