### PR TITLE
Update conditions to reflect degraded and resyncing

### DIFF
--- a/controllers/status.go
+++ b/controllers/status.go
@@ -86,13 +86,19 @@ func setFailedPromotionCondition(conditions *[]metav1.Condition, observedGenerat
 	})
 }
 
-// sets conditions when volume is demoted and requeued for resync
-func setOnlyDegradedCondition(conditions *[]metav1.Condition, observedGeneration int64) {
+// sets conditions when volume is demoted and ready to use (resync completed)
+func setNotDegradedCondition(conditions *[]metav1.Condition, observedGeneration int64) {
 	setStatusCondition(conditions, metav1.Condition{
 		Type:               ConditionDegraded,
-		Reason:             VolumeDegraded,
+		Reason:             Healthy,
 		ObservedGeneration: observedGeneration,
-		Status:             metav1.ConditionTrue,
+		Status:             metav1.ConditionFalse,
+	})
+	setStatusCondition(conditions, metav1.Condition{
+		Type:               ConditionResyncing,
+		Reason:             NotResyncing,
+		ObservedGeneration: observedGeneration,
+		Status:             metav1.ConditionFalse,
 	})
 }
 
@@ -106,9 +112,9 @@ func setDemotedCondition(conditions *[]metav1.Condition, observedGeneration int6
 	})
 	setStatusCondition(conditions, metav1.Condition{
 		Type:               ConditionDegraded,
-		Reason:             Healthy,
+		Reason:             VolumeDegraded,
 		ObservedGeneration: observedGeneration,
-		Status:             metav1.ConditionFalse,
+		Status:             metav1.ConditionTrue,
 	})
 	setStatusCondition(conditions, metav1.Condition{
 		Type:               ConditionResyncing,
@@ -150,22 +156,6 @@ func setResyncCondition(conditions *[]metav1.Condition, observedGeneration int64
 		ObservedGeneration: observedGeneration,
 		Status:             metav1.ConditionTrue,
 	})
-	setStatusCondition(conditions, metav1.Condition{
-		Type:               ConditionDegraded,
-		Reason:             Healthy,
-		ObservedGeneration: observedGeneration,
-		Status:             metav1.ConditionFalse,
-	})
-	setStatusCondition(conditions, metav1.Condition{
-		Type:               ConditionResyncing,
-		Reason:             ResyncTriggered,
-		ObservedGeneration: observedGeneration,
-		Status:             metav1.ConditionTrue,
-	})
-}
-
-// sets conditions when volume resync is triggered but is not ready to use
-func setDegradedCondition(conditions *[]metav1.Condition, observedGeneration int64) {
 	setStatusCondition(conditions, metav1.Condition{
 		Type:               ConditionDegraded,
 		Reason:             VolumeDegraded,


### PR DESCRIPTION
The condition updates are when processing as secondary

- Resyncing
  - Is false on any errors
  - Is false if degraded is false
  - Is true, if resync is successful and volume is not
    yet "ready" to use
- Degraded
  - Is true on errors
  - Is true UNTIL resync returns "ready" response
  - Is false ONLY when resync returns "ready"

As Degraded moves to false, resyncing will move to
false as well, other than cases where there are
errors, or resync status is not yet determined. Resync
status is for example undetermined if we issued a
demote volume request, from markVolAsSecondary.

Resyncing: denotes if resync is active
Degraded: denotes local secondary contents are not
in full sync with remote, and that happens only when
remote is marked Secondary and local is also Secondary
and the final sync is complete.

Hence, Resyncing is false when degraded is false, as
there is no more data to sync.

Completed is always the initial condition to check before
looking at other conditions, to ensure operation was a
success. IOW, Completed being false, currently negates
any value in the other 2 conditions, and should typically
be Resync: false and Degraded: true.

Fixes: #101

Signed-off-by: Shyamsundar Ranganathan <srangana@redhat.com>