### PR TITLE
replication: add grpc message to CR status

### DIFF
--- a/controllers/replication/replication.go
+++ b/controllers/replication/replication.go
@@ -120,3 +120,15 @@ func (r *ReplicationResponse) HasKnownGRPCError(knownErrors []codes.Code) bool {
 
 	return false
 }
+
+// GetMessageFromError returns the message from the error.
+func GetMessageFromError(err error) string {
+	s, ok := status.FromError(err)
+	if !ok {
+		// This is not gRPC error. The operation must have failed before gRPC
+		// method was called, otherwise we would get gRPC error.
+		return err.Error()
+	}
+
+	return s.Message()
+}

--- a/controllers/replication/replication_test.go
+++ b/controllers/replication/replication_test.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2021.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package replication
+
+import (
+	"errors"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestGetMessageFromError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{
+			name: "test GRPC error message",
+			err:  status.Error(codes.Internal, "failure"),
+			want: "failure",
+		},
+		{
+			name: "test non grpc error message",
+			err:  errors.New("non grpc failure"),
+			want: "non grpc failure",
+		},
+		{
+			name: "test nil error",
+			err:  nil,
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GetMessageFromError(tt.err); got != tt.want {
+				t.Errorf("GetMessageFromError() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/controllers/volumereplication_controller.go
+++ b/controllers/volumereplication_controller.go
@@ -208,7 +208,8 @@ func (r *VolumeReplicationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	if err = r.enableReplication(logger, volumeHandle, replicationHandle, parameters, secret); err != nil {
 		logger.Error(err, "failed to enable replication")
 		setFailureCondition(instance)
-		_ = r.updateReplicationStatus(instance, logger, getCurrentReplicationState(instance), err.Error())
+		msg := replication.GetMessageFromError(err)
+		_ = r.updateReplicationStatus(instance, logger, getCurrentReplicationState(instance), msg)
 		return reconcile.Result{}, err
 	}
 
@@ -259,8 +260,9 @@ func (r *VolumeReplicationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	}
 
 	if replicationErr != nil {
+		msg := replication.GetMessageFromError(replicationErr)
 		logger.Error(replicationErr, "failed to Replicate", "ReplicationState", instance.Spec.ReplicationState)
-		_ = r.updateReplicationStatus(instance, logger, getCurrentReplicationState(instance), replicationErr.Error())
+		_ = r.updateReplicationStatus(instance, logger, getCurrentReplicationState(instance), msg)
 		if instance.Status.State == replicationv1alpha1.SecondaryState {
 			return ctrl.Result{
 				Requeue: true,


### PR DESCRIPTION
instead of adding both the GRPC error code and the message to CR status just update the CR with the GRPC error message for better readability.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

* Before Fix

```yaml
lastStartTime: "2021-11-30T06:46:52Z"
message: 'rpc error: code = Internal desc = failed to get local status: rbd: ret=-2,
No such file or directory'
observedGeneration: 2
state: Unknown
```
* After Fix

```yaml
lastStartTime: "2021-11-30T06:46:52Z"
message: 'failed to get local status: rbd: ret=-2, No such file or directory'
observedGeneration: 2
state: Unknown
```