### PR TITLE
ci: update mergifyio config to use queue action

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,13 +1,19 @@
 ---
 defaults:
   actions:
-    comment:
-    merge:
+    queue:
+      name: default
       method: rebase
       rebase_fallback: merge
-      strict: smart
-      strict_method: rebase
-    rebase:
+      update_method: rebase
+
+queue_rules:
+  - name: default
+    conditions:
+      - "status-success=codespell"
+      - "status-success=test and build (1.16)"
+      - "status-success=lint"
+      - "status-success=DCO"
 
 pull_request_rules:
   - name: remove outdated approvals
@@ -37,7 +43,7 @@ pull_request_rules:
       - "status-success=lint"
       - "status-success=DCO"
     actions:
-      merge: {}
+      queue: {}
       dismiss_reviews: {}
       delete_head_branch: {}
   - name: automatic merge PR having ready-to-merge label
@@ -52,7 +58,7 @@ pull_request_rules:
       - "status-success=lint"
       - "status-success=DCO"
     actions:
-      merge: {}
+      queue: {}
       dismiss_reviews: {}
       delete_head_branch: {}
   - name: backport patches to release v0.1 branch


### PR DESCRIPTION
Mergifyio is deprecating `merge` action, which will be replaced by `queue` action. https://blog.mergify.com/strict-mode-deprecation/

This commit makes necessary changes for the same.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>